### PR TITLE
Add object scope filtering and documentation for fetch scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Add the following to your workflow and supply `SFDX_AUTH_URL` and `SF_USERNAME` 
   with:
     format: json           # json | csv | json-per-object | csv-per-object
     output_dir: docs       # directory relative to the caller's workspace (default: docs)
+    object_scope: all      # all | system | custom
     sfdx_auth_url: ${{ secrets.SFDX_AUTH_URL }}
     sf_username: ${{ secrets.SF_USERNAME }}
 ```
@@ -26,6 +27,7 @@ Add the following to your workflow and supply `SFDX_AUTH_URL` and `SF_USERNAME` 
 | ---- | -------- | ------- | ----------- |
 | `format` | Yes | `json` | Output format: `json`, `csv`, `json-per-object`, or `csv-per-object`. |
 | `output_dir` | No | `docs` | Directory (relative to the caller's workspace) where output files are written. |
+| `object_scope` | No | `all` | Object filter: `all`, `system` (standard objects only), or `custom` (objects whose API name contains `__`). |
 | `sfdx_auth_url` | Yes | — | SFDX Auth URL for authenticating to Salesforce. |
 | `sf_username` | Yes | — | Salesforce username to query as. |
 
@@ -65,6 +67,7 @@ jobs:
         with:
           format: json
           output_dir: docs
+          object_scope: all
           sfdx_auth_url: ${{ secrets.SFDX_AUTH_URL }}
           sf_username: ${{ secrets.SF_USERNAME }}
 

--- a/action.yml
+++ b/action.yml
@@ -1,32 +1,36 @@
-name: 'Fetch Salesforce Field Definitions'
-description: 'Fetch FieldDefinition records from Salesforce Tooling API and save them to a file or directory.'
+name: "Fetch Salesforce Field Definitions"
+description: "Fetch FieldDefinition records from Salesforce Tooling API and save them to a file or directory."
 
 inputs:
   format:
-    description: 'Output format. One of: json, csv, json-per-object, csv-per-object.'
+    description: "Output format. One of: json, csv, json-per-object, csv-per-object."
     required: true
-    default: 'json'
+    default: "json"
   output_dir:
-    description: 'Directory to write output files into. Defaults to docs/ relative to the caller workspace.'
+    description: "Directory to write output files into. Defaults to docs/ relative to the caller workspace."
     required: false
-    default: 'docs'
+    default: "docs"
+  object_scope:
+    description: "Object scope filter. One of: all, system, custom."
+    required: false
+    default: "all"
   sfdx_auth_url:
-    description: 'SFDX Auth URL used to authenticate to Salesforce (e.g. from secrets.SFDX_AUTH_URL).'
+    description: "SFDX Auth URL used to authenticate to Salesforce (e.g. from secrets.SFDX_AUTH_URL)."
     required: true
   sf_username:
-    description: 'Salesforce username to run queries as (e.g. from secrets.SF_USERNAME).'
+    description: "Salesforce username to run queries as (e.g. from secrets.SF_USERNAME)."
     required: true
 
 branding:
-  icon: 'search'
-  color: 'blue'
+  icon: "search"
+  color: "blue"
 
 runs:
-  using: 'composite'
+  using: "composite"
   steps:
     - uses: actions/setup-node@v4
       with:
-        node-version: '20'
+        node-version: "20"
 
     - name: Install dependencies
       shell: bash
@@ -45,4 +49,4 @@ runs:
       env:
         SF_USERNAME: ${{ inputs.sf_username }}
         OUTPUT_DIR: ${{ github.workspace }}/${{ inputs.output_dir }}
-      run: node ${{ github.action_path }}/scripts/fetch-field-definitions.js ${{ inputs.format }}
+      run: node ${{ github.action_path }}/scripts/fetch-field-definitions.js ${{ inputs.format }} ${{ inputs.object_scope }}

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -37,6 +37,11 @@ npm run fetch-field-definitions:json
 npm run fetch-field-definitions:csv
 npm run fetch-field-definitions:json-per-object
 npm run fetch-field-definitions:csv-per-object
+
+# Optional: pass object scope with npm run
+# all (default) | system | custom
+npm run fetch-field-definitions:json -- system
+npm run fetch-field-definitions:json -- custom
 ```
 
 ## Tests

--- a/scripts/fetch-field-definitions.js
+++ b/scripts/fetch-field-definitions.js
@@ -6,6 +6,7 @@ import { saveResults, saveResultsAsCsv, saveResultsPerObject, saveResultsAsCsvPe
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
 const format = process.argv[2];
+const objectScope = process.argv[3] ?? 'all';
 
 const username = process.env.SF_USERNAME;
 if (!username) {
@@ -13,7 +14,7 @@ if (!username) {
   process.exit(1);
 }
 
-const data = await fetchFieldDefinitions(username).catch((err) => {
+const data = await fetchFieldDefinitions(username, objectScope).catch((err) => {
   console.error(err);
   process.exit(1);
 });

--- a/scripts/lib/fetch.js
+++ b/scripts/lib/fetch.js
@@ -1,6 +1,7 @@
 import { AuthInfo, Connection } from '@salesforce/core';
 
 const ENTITY_ID_PATTERN = /^[A-Za-z0-9_]+$/;
+const OBJECT_SCOPE_VALUES = new Set(['all', 'system', 'custom']);
 // Query one entity at a time so each batch stays well within the 2000-record
 // SOQL OFFSET ceiling.  Salesforce limits a single object to ~800 custom fields,
 // meaning one entity's fields always fit in a single LIMIT 2000 page.
@@ -19,23 +20,53 @@ function isValidDurableId(id) {
 }
 
 /**
+ * Determine whether an object DurableId should be treated as custom.
+ * Custom Salesforce objects use double underscore naming (for example: __c, __mdt, __e).
+ * @param {string} durableId
+ * @returns {boolean}
+ */
+function isCustomObjectDurableId(durableId) {
+  return typeof durableId === 'string' && durableId.includes('__');
+}
+
+/**
+ * Return true when an object ID matches the requested scope.
+ * @param {string} durableId
+ * @param {'all' | 'system' | 'custom'} objectScope
+ * @returns {boolean}
+ */
+function matchesObjectScope(durableId, objectScope) {
+  if (objectScope === 'all') {
+    return true;
+  }
+
+  const isCustom = isCustomObjectDurableId(durableId);
+  return objectScope === 'custom' ? isCustom : !isCustom;
+}
+
+/**
  * Query all EntityDefinition DurableIds from the Tooling API.
  * @param {Connection} connection - Salesforce connection
+ * @param {'all' | 'system' | 'custom'} objectScope - Object filter scope
  * @returns {string[]} - Array of DurableId values
  */
-async function fetchEntityDefinitionIds(connection) {
+async function fetchEntityDefinitionIds(connection, objectScope) {
   let ids = [];
   let result = await connection.tooling.query(
     'SELECT DurableId FROM EntityDefinition ORDER BY DurableId LIMIT 2000'
   );
   for (const record of result.records) {
-    ids.push(record.DurableId);
+    if (matchesObjectScope(record.DurableId, objectScope)) {
+      ids.push(record.DurableId);
+    }
   }
 
   while (!result.done && result.nextRecordsUrl) {
     result = await connection.tooling.queryMore(result.nextRecordsUrl);
     for (const record of result.records) {
-      ids.push(record.DurableId);
+      if (matchesObjectScope(record.DurableId, objectScope)) {
+        ids.push(record.DurableId);
+      }
     }
   }
 
@@ -92,15 +123,23 @@ async function fetchFieldDefinitionBatch(connection, entityIds) {
 /**
  * Query all FieldDefinition records from the Tooling API.
  * @param {string} username - Salesforce username to authenticate as
+ * @param {'all' | 'system' | 'custom'} [objectScope='all'] - Object filter scope
  * @returns {{ instanceUrl: string, records: object[] }}
  */
-export async function fetchFieldDefinitions(username) {
+export async function fetchFieldDefinitions(username, objectScope = 'all') {
+  if (!OBJECT_SCOPE_VALUES.has(objectScope)) {
+    throw new Error(
+      `Invalid object scope: ${objectScope}. Use one of: all, system, custom.`
+    );
+  }
+
   const authInfo = await AuthInfo.create({ username });
   const connection = await Connection.create({ authInfo });
 
   console.log(`Connected to: ${connection.instanceUrl}`);
+  console.log(`Object scope: ${objectScope}`);
 
-  const allEntityIds = await fetchEntityDefinitionIds(connection);
+  const allEntityIds = await fetchEntityDefinitionIds(connection, objectScope);
   const invalidEntityIds = allEntityIds.filter((id) => !isValidDurableId(id));
   if (invalidEntityIds.length > 0) {
     console.warn(`Skipping ${invalidEntityIds.length} EntityDefinition record(s) with invalid DurableId.`);

--- a/scripts/lib/fetch.test.js
+++ b/scripts/lib/fetch.test.js
@@ -189,3 +189,41 @@ describe('isValidDurableId (via fetchFieldDefinitions)', () => {
     expect(result.records).toEqual([]);
   });
 });
+
+describe('object scope filtering', () => {
+  it('keeps only system objects when scope is system', async () => {
+    const entityRecords = [{ DurableId: 'Account' }, { DurableId: 'MyObject__c' }];
+    const systemField = { Id: 'aaa000', EntityDefinitionId: 'Account' };
+
+    const mockConn = buildMockConnection(entityRecords, [systemField]);
+    AuthInfo.create.mockResolvedValue({});
+    Connection.create.mockResolvedValue(mockConn);
+
+    await fetchFieldDefinitions('user@example.com', 'system');
+
+    const fieldQuery = mockConn.tooling.query.mock.calls[1][0];
+    expect(fieldQuery).toContain("'Account'");
+    expect(fieldQuery).not.toContain('MyObject__c');
+  });
+
+  it('keeps only custom objects when scope is custom', async () => {
+    const entityRecords = [{ DurableId: 'Account' }, { DurableId: 'MyObject__c' }];
+    const customField = { Id: 'bbb111', EntityDefinitionId: 'MyObject__c' };
+
+    const mockConn = buildMockConnection(entityRecords, [customField]);
+    AuthInfo.create.mockResolvedValue({});
+    Connection.create.mockResolvedValue(mockConn);
+
+    await fetchFieldDefinitions('user@example.com', 'custom');
+
+    const fieldQuery = mockConn.tooling.query.mock.calls[1][0];
+    expect(fieldQuery).toContain('MyObject__c');
+    expect(fieldQuery).not.toContain("'Account'");
+  });
+
+  it('throws an error for unsupported object scope', async () => {
+    await expect(fetchFieldDefinitions('user@example.com', 'unsupported'))
+      .rejects
+      .toThrow('Invalid object scope: unsupported. Use one of: all, system, custom.');
+  });
+});


### PR DESCRIPTION
This pull request introduces an "object scope" filter to allow users to restrict which Salesforce objects are included when fetching field definitions. Users can now choose to fetch all objects, only standard (system) objects, or only custom objects, improving flexibility and control over the data retrieved. The change is reflected in the action inputs, documentation, core fetching logic, and test coverage.

**Feature: Object Scope Filtering**
- Added a new `object_scope` input to the GitHub Action (`action.yml`) with options `all`, `system`, or `custom`, defaulting to `all`. This input is now passed through the workflow and CLI, allowing users to control which object types are included. [[1]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L1-R33) [[2]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L48-R52) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R19) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R70) [[5]](diffhunk://#diff-25b96aa16f8b9f68c692d0db061713707e9cfc67b296e0ea30908928fb3ffcd6R40-R44)
- Updated the documentation in `README.md` and `scripts/README.md` to explain the new `object_scope` option, its usage, and possible values. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R30) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R19) [[3]](diffhunk://#diff-25b96aa16f8b9f68c692d0db061713707e9cfc67b296e0ea30908928fb3ffcd6R40-R44) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R70)

**Implementation: Filtering Logic**
- Enhanced the fetching logic in `scripts/lib/fetch.js` to filter object DurableIds based on the specified `object_scope`, using helper functions to distinguish between system and custom objects. The main fetching function validates the input and applies the filter throughout the paging process. [[1]](diffhunk://#diff-b70d2defa305a97919f31f08ffd66df876040271172e7d3f7e689412a336b391R4) [[2]](diffhunk://#diff-b70d2defa305a97919f31f08ffd66df876040271172e7d3f7e689412a336b391R22-R71) [[3]](diffhunk://#diff-b70d2defa305a97919f31f08ffd66df876040271172e7d3f7e689412a336b391R126-R142)
- Updated the CLI entry point (`scripts/fetch-field-definitions.js`) to accept and forward the `object_scope` argument to the fetching logic.

**Testing: Coverage for Filtering**
- Added new tests to `scripts/lib/fetch.test.js` to verify that the object scope filter works as intended for system, custom, and invalid scope values.