### PR TITLE
Add support for custom FieldDefinition select fields and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Add the following to your workflow and supply `SFDX_AUTH_URL` and `SF_USERNAME` 
     format: json           # json | csv | json-per-object | csv-per-object
     output_dir: docs       # directory relative to the caller's workspace (default: docs)
     object_scope: all      # all | system | custom
+    field_definition_fields: Id,DurableId,QualifiedApiName,EntityDefinitionId
     sfdx_auth_url: ${{ secrets.SFDX_AUTH_URL }}
     sf_username: ${{ secrets.SF_USERNAME }}
 ```
@@ -28,6 +29,7 @@ Add the following to your workflow and supply `SFDX_AUTH_URL` and `SF_USERNAME` 
 | `format` | Yes | `json` | Output format: `json`, `csv`, `json-per-object`, or `csv-per-object`. |
 | `output_dir` | No | `docs` | Directory (relative to the caller's workspace) where output files are written. |
 | `object_scope` | No | `all` | Object filter: `all`, `system` (standard objects only), or `custom` (objects whose API name contains `__`). |
+| `field_definition_fields` | No | empty (all supported fields) | Comma-separated FieldDefinition fields to select. Supported fields: `Id`, `DurableId`, `QualifiedApiName`, `EntityDefinitionId`, `NamespacePrefix`, `DeveloperName`, `MasterLabel`, `Label`, `DataType`, `IsCalculated`, `IsNillable`, `IsIndexed`, `IsApiFilterable`, `IsApiGroupable`, `IsApiSortable`. |
 | `sfdx_auth_url` | Yes | — | SFDX Auth URL for authenticating to Salesforce. |
 | `sf_username` | Yes | — | Salesforce username to query as. |
 
@@ -68,6 +70,8 @@ jobs:
           format: json
           output_dir: docs
           object_scope: all
+          # Optional: narrow selected FieldDefinition columns
+          field_definition_fields: Id,DurableId,QualifiedApiName,EntityDefinitionId
           sfdx_auth_url: ${{ secrets.SFDX_AUTH_URL }}
           sf_username: ${{ secrets.SF_USERNAME }}
 

--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,10 @@ inputs:
     description: "Object scope filter. One of: all, system, custom."
     required: false
     default: "all"
+  field_definition_fields:
+    description: "Comma-separated FieldDefinition fields to select. Defaults to all supported fields."
+    required: false
+    default: ""
   sfdx_auth_url:
     description: "SFDX Auth URL used to authenticate to Salesforce (e.g. from secrets.SFDX_AUTH_URL)."
     required: true
@@ -49,4 +53,5 @@ runs:
       env:
         SF_USERNAME: ${{ inputs.sf_username }}
         OUTPUT_DIR: ${{ github.workspace }}/${{ inputs.output_dir }}
+        FIELD_DEFINITION_FIELDS: ${{ inputs.field_definition_fields }}
       run: node ${{ github.action_path }}/scripts/fetch-field-definitions.js ${{ inputs.format }} ${{ inputs.object_scope }}

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -21,6 +21,10 @@ sf org login web --alias my-org
 sf org list --all
 
 export SF_USERNAME="your.username@example.com"
+
+# Optional: comma-separated FieldDefinition fields to select.
+# If omitted, all supported fields are selected.
+export FIELD_DEFINITION_FIELDS="Id,DurableId,QualifiedApiName,EntityDefinitionId"
 ```
 
 ## Run Scripts Locally

--- a/scripts/fetch-field-definitions.js
+++ b/scripts/fetch-field-definitions.js
@@ -7,6 +7,9 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 
 const format = process.argv[2];
 const objectScope = process.argv[3] ?? 'all';
+const fieldDefinitionFields = process.env.FIELD_DEFINITION_FIELDS
+  ? process.env.FIELD_DEFINITION_FIELDS.split(',').map((field) => field.trim()).filter(Boolean)
+  : undefined;
 
 const username = process.env.SF_USERNAME;
 if (!username) {
@@ -14,7 +17,7 @@ if (!username) {
   process.exit(1);
 }
 
-const data = await fetchFieldDefinitions(username, objectScope).catch((err) => {
+const data = await fetchFieldDefinitions(username, objectScope, fieldDefinitionFields).catch((err) => {
   console.error(err);
   process.exit(1);
 });

--- a/scripts/lib/fetch.js
+++ b/scripts/lib/fetch.js
@@ -2,6 +2,25 @@ import { AuthInfo, Connection } from '@salesforce/core';
 
 const ENTITY_ID_PATTERN = /^[A-Za-z0-9_]+$/;
 const OBJECT_SCOPE_VALUES = new Set(['all', 'system', 'custom']);
+const FIELD_NAME_PATTERN = /^[A-Za-z][A-Za-z0-9_]*$/;
+const ALLOWED_FIELD_DEFINITION_FIELDS = [
+  'Id',
+  'DurableId',
+  'QualifiedApiName',
+  'EntityDefinitionId',
+  'NamespacePrefix',
+  'DeveloperName',
+  'MasterLabel',
+  'Label',
+  'DataType',
+  'IsCalculated',
+  'IsNillable',
+  'IsIndexed',
+  'IsApiFilterable',
+  'IsApiGroupable',
+  'IsApiSortable',
+];
+const ALLOWED_FIELD_DEFINITION_FIELD_SET = new Set(ALLOWED_FIELD_DEFINITION_FIELDS);
 // Query one entity at a time so each batch stays well within the 2000-record
 // SOQL OFFSET ceiling.  Salesforce limits a single object to ~800 custom fields,
 // meaning one entity's fields always fit in a single LIMIT 2000 page.
@@ -45,6 +64,43 @@ function matchesObjectScope(durableId, objectScope) {
 }
 
 /**
+ * Validate and normalize requested FieldDefinition select fields.
+ * @param {string[] | undefined} fields
+ * @returns {string[]}
+ */
+function normalizeFieldDefinitionFields(fields) {
+  if (fields == null) {
+    return ALLOWED_FIELD_DEFINITION_FIELDS;
+  }
+
+  if (!Array.isArray(fields)) {
+    throw new Error('fieldDefinitionFields must be an array of field names.');
+  }
+
+  const normalized = fields
+    .map((field) => (typeof field === 'string' ? field.trim() : field))
+    .filter((field) => field !== '');
+
+  if (normalized.length === 0) {
+    throw new Error('fieldDefinitionFields must include at least one field.');
+  }
+
+  for (const field of normalized) {
+    if (typeof field !== 'string' || !FIELD_NAME_PATTERN.test(field)) {
+      throw new Error(`Invalid field name: ${String(field)}.`);
+    }
+    if (!ALLOWED_FIELD_DEFINITION_FIELD_SET.has(field)) {
+      throw new Error(
+        `Unsupported field name: ${field}. Allowed fields: ${ALLOWED_FIELD_DEFINITION_FIELDS.join(', ')}.`
+      );
+    }
+  }
+
+  // Deduplicate while preserving order.
+  return [...new Set(normalized)];
+}
+
+/**
  * Query all EntityDefinition DurableIds from the Tooling API.
  * @param {Connection} connection - Salesforce connection
  * @param {'all' | 'system' | 'custom'} objectScope - Object filter scope
@@ -82,16 +138,18 @@ async function fetchEntityDefinitionIds(connection, objectScope) {
  * remain in place as a safety net for any unexpected edge case.
  * @param {Connection} connection - Salesforce connection
  * @param {string[]} entityIds - Array of validated EntityDefinition DurableId values
+ * @param {string[]} fieldDefinitionFields - Validated FieldDefinition select fields
  * @returns {object[]} - Array of FieldDefinition records
  */
-async function fetchFieldDefinitionBatch(connection, entityIds) {
+async function fetchFieldDefinitionBatch(connection, entityIds, fieldDefinitionFields) {
   const inList = entityIds.map((id) => `'${id}'`).join(', ');
+  const selectClause = fieldDefinitionFields.join(', ');
   let records = [];
   let offset = 0;
 
   while (true) {
     const soql =
-      `SELECT Id, DurableId, QualifiedApiName, EntityDefinitionId, NamespacePrefix, DeveloperName, MasterLabel, Label, DataType, IsCalculated, IsNillable, IsIndexed, IsApiFilterable, IsApiGroupable, IsApiSortable` +
+      `SELECT ${selectClause}` +
       ` FROM FieldDefinition WHERE EntityDefinitionId IN (${inList})` +
       ` ORDER BY EntityDefinitionId, DurableId LIMIT ${PAGE_SIZE} OFFSET ${offset}`;
     const result = await connection.tooling.query(soql);
@@ -124,14 +182,16 @@ async function fetchFieldDefinitionBatch(connection, entityIds) {
  * Query all FieldDefinition records from the Tooling API.
  * @param {string} username - Salesforce username to authenticate as
  * @param {'all' | 'system' | 'custom'} [objectScope='all'] - Object filter scope
+ * @param {string[]} [fieldDefinitionFields] - FieldDefinition select fields
  * @returns {{ instanceUrl: string, records: object[] }}
  */
-export async function fetchFieldDefinitions(username, objectScope = 'all') {
+export async function fetchFieldDefinitions(username, objectScope = 'all', fieldDefinitionFields) {
   if (!OBJECT_SCOPE_VALUES.has(objectScope)) {
     throw new Error(
       `Invalid object scope: ${objectScope}. Use one of: all, system, custom.`
     );
   }
+  const selectFields = normalizeFieldDefinitionFields(fieldDefinitionFields);
 
   const authInfo = await AuthInfo.create({ username });
   const connection = await Connection.create({ authInfo });
@@ -150,7 +210,7 @@ export async function fetchFieldDefinitions(username, objectScope = 'all') {
   let records = [];
   for (let i = 0; i < validEntityIds.length; i += BATCH_SIZE) {
     const batch = validEntityIds.slice(i, i + BATCH_SIZE);
-    const batchRecords = await fetchFieldDefinitionBatch(connection, batch);
+    const batchRecords = await fetchFieldDefinitionBatch(connection, batch, selectFields);
     records = records.concat(batchRecords);
     const processed = Math.min(i + BATCH_SIZE, validEntityIds.length);
     console.log(`Fetching FieldDefinitions: ${processed}/${validEntityIds.length} entities processed (${records.length} records so far)`);

--- a/scripts/lib/fetch.test.js
+++ b/scripts/lib/fetch.test.js
@@ -60,6 +60,11 @@ describe('fetchFieldDefinitions', () => {
 
     expect(result.instanceUrl).toBe('https://example.my.salesforce.com');
     expect(result.records).toEqual(fieldRecords);
+
+    const fieldQuery = mockConn.tooling.query.mock.calls[1][0];
+    expect(fieldQuery).toContain(
+      'SELECT Id, DurableId, QualifiedApiName, EntityDefinitionId, NamespacePrefix, DeveloperName, MasterLabel, Label, DataType, IsCalculated, IsNillable, IsIndexed, IsApiFilterable, IsApiGroupable, IsApiSortable'
+    );
   });
 
   it('calls AuthInfo.create and Connection.create with the given username', async () => {
@@ -127,6 +132,47 @@ describe('fetchFieldDefinitions', () => {
     expect(result.records).toHaveLength(2);
     expect(result.records).toContainEqual(accountField);
     expect(result.records).toContainEqual(contactField);
+  });
+
+  it('uses only requested select fields when field list is provided', async () => {
+    const entityRecords = [{ DurableId: 'Account' }];
+    const fieldRecords = [{ Id: 'aaa000', EntityDefinitionId: 'Account' }];
+
+    const mockConn = buildMockConnection(entityRecords, fieldRecords);
+    AuthInfo.create.mockResolvedValue({});
+    Connection.create.mockResolvedValue(mockConn);
+
+    await fetchFieldDefinitions('user@example.com', 'all', ['Id', 'EntityDefinitionId']);
+
+    const fieldQuery = mockConn.tooling.query.mock.calls[1][0];
+    expect(fieldQuery).toContain('SELECT Id, EntityDefinitionId FROM FieldDefinition');
+    expect(fieldQuery).not.toContain('QualifiedApiName');
+  });
+
+  it('throws when requested fields include unsupported names', async () => {
+    await expect(fetchFieldDefinitions('user@example.com', 'all', ['Id', 'UnknownField']))
+      .rejects
+      .toThrow('Unsupported field name: UnknownField.');
+  });
+
+  it('throws when requested fields include invalid characters', async () => {
+    await expect(fetchFieldDefinitions('user@example.com', 'all', ['Id', 'Name, DurableId']))
+      .rejects
+      .toThrow('Invalid field name: Name, DurableId.');
+  });
+
+  it('deduplicates requested fields while preserving order', async () => {
+    const entityRecords = [{ DurableId: 'Account' }];
+    const fieldRecords = [{ Id: 'aaa000', EntityDefinitionId: 'Account' }];
+
+    const mockConn = buildMockConnection(entityRecords, fieldRecords);
+    AuthInfo.create.mockResolvedValue({});
+    Connection.create.mockResolvedValue(mockConn);
+
+    await fetchFieldDefinitions('user@example.com', 'all', ['Id', 'Id', 'EntityDefinitionId']);
+
+    const fieldQuery = mockConn.tooling.query.mock.calls[1][0];
+    expect(fieldQuery).toContain('SELECT Id, EntityDefinitionId FROM FieldDefinition');
   });
 
   it('follows queryMore for EntityDefinition pagination', async () => {


### PR DESCRIPTION
This pull request adds support for selecting specific `FieldDefinition` fields when fetching Salesforce metadata, allowing users to limit the columns returned in the output. The change is implemented across the GitHub Action, documentation, scripts, and tests to ensure users can optionally specify a comma-separated list of allowed fields. Validation and error handling are included to catch unsupported or invalid field names.

**User-facing enhancements:**

* Added a new optional `field_definition_fields` input to the GitHub Action (`action.yml`) and documented its usage in `README.md` and `scripts/README.md`. This allows users to specify which `FieldDefinition` columns to select, improving performance and customization. [[1]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6R17-R20) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R20) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R32) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R73-R74) [[5]](diffhunk://#diff-25b96aa16f8b9f68c692d0db061713707e9cfc67b296e0ea30908928fb3ffcd6R24-R27)

**Script and backend improvements:**

* Updated `scripts/fetch-field-definitions.js` and `scripts/lib/fetch.js` to accept and validate the `FIELD_DEFINITION_FIELDS` environment variable, passing the selected fields through to the SOQL query. Only allowed fields are accepted, with validation and deduplication. [[1]](diffhunk://#diff-049658a1fddf276f79777d22e727c2541c47d2e35fcebad71adfe837ebd06186R10-R20) [[2]](diffhunk://#diff-b70d2defa305a97919f31f08ffd66df876040271172e7d3f7e689412a336b391R5-R23) [[3]](diffhunk://#diff-b70d2defa305a97919f31f08ffd66df876040271172e7d3f7e689412a336b391R66-R102) [[4]](diffhunk://#diff-b70d2defa305a97919f31f08ffd66df876040271172e7d3f7e689412a336b391R141-R152) [[5]](diffhunk://#diff-b70d2defa305a97919f31f08ffd66df876040271172e7d3f7e689412a336b391R185-R194) [[6]](diffhunk://#diff-b70d2defa305a97919f31f08ffd66df876040271172e7d3f7e689412a336b391L153-R213)
* The SOQL query in `fetchFieldDefinitionBatch` is now dynamically constructed based on the requested fields, instead of always selecting all columns.

**Testing and validation:**

* Extended tests in `scripts/lib/fetch.test.js` to cover custom field selection, validation of allowed fields, error handling for invalid/unsupported fields, and deduplication of field names. [[1]](diffhunk://#diff-8a7c9767d39ca84ca57923497978b0d3defcc1f46e56e170d6f3235b89d904ebR63-R67) [[2]](diffhunk://#diff-8a7c9767d39ca84ca57923497978b0d3defcc1f46e56e170d6f3235b89d904ebR137-R177)

**Action execution:**

* Updated the GitHub Action runner to pass the new input as an environment variable to the script.